### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -17,7 +17,7 @@
     ],
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
-  "nxCloudId": "671dea446ff0aaace543862f",
+  "nxCloudId": "67422e1e1ef91af262ecd1b2",
   "targetDefaults": {
     "@angular-devkit/build-angular:application": {
       "cache": true,


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace 
    
This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to 
https://cloud.nx.app/orgs/6470f82042e352000ea83bdb/workspaces/67422e1e1ef91af262ecd1b2

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.